### PR TITLE
fix: Replace dbc.FormGroup with dbc.Row

### DIFF
--- a/Bootstrap/bootstrap_modal.py
+++ b/Bootstrap/bootstrap_modal.py
@@ -19,21 +19,21 @@ modal = html.Div(
             dbc.ModalBody(
                 dbc.Form(
                     [
-                        dbc.FormGroup(
+                        dbc.Row(
                             [
                                 dbc.Label("Name", className="mr-2"),
                                 dbc.Input(type="text", placeholder="Enter your name"),
                             ],
                             className="mr-3",
                         ),
-                        dbc.FormGroup(
+                        dbc.Row(
                             [
                                 dbc.Label("Email", className="mr-2"),
                                 dbc.Input(type="email", placeholder="Enter email"),
                             ],
                             className="mr-3",
                         ),
-                        dbc.FormGroup(
+                        dbc.Row(
                             [
                                 dbc.Label("Comment", className="mr-2"),
                                 dbc.Input(type="text", placeholder="Enter comment"),


### PR DESCRIPTION
Deals with the following error that prevents app from running: raise AttributeError(AttributeError: FormGroup was deprecated in dash-bootstrap-components version 1.0.0 You are using 1.6.0.

Trying to run the app with the original code with `python3 bootstrap_modal.py` results in the error above. 

Below is full error traceback on that pops up: 
```
Traceback (most recent call last):
  File "/home/mutuma/code/Plotly_Dash_Practice/3_charming_data_bootstrap_alerts_n_modals/app.py", line 19, in <module>
    dbc.FormGroup(
  File "/home/mutuma/code/Plotly_Dash_Practice/2_charming_data_bootstrap_cards/venv/lib/python3.10/site-packages/dash_bootstrap_components/__init__.py", line 51, in __getattr__
    raise AttributeError(
AttributeError: FormGroup was deprecated in dash-bootstrap-components version 1.0.0. You are using 1.6.0. For more details please see the migration guide: https://github.com/facultyai/dash-bootstrap-components/blob/6da4a97f940483deb3dc9c815ef4c7e450ff0be7/docs/content/migration-guide.md. Did you mean: 'CardGroup'?
```