### PR TITLE
fix: Remove inline=True property from Form dbc

### DIFF
--- a/Bootstrap/bootstrap_modal.py
+++ b/Bootstrap/bootstrap_modal.py
@@ -42,7 +42,6 @@ modal = html.Div(
                         ),
                         dbc.Button("Submit", color="primary"),
                     ],
-                    inline=True,
                 )
             ),
             dbc.ModalFooter(


### PR DESCRIPTION
Presence of `inline=True` style property on the Form component throws a type error: 

raise TypeError(TypeError: The `dash_bootstrap_components.Form` component (version 1.6.0)received an unexpected keyword argument: `inline`

The above error prevents the app from running with the `python3 bootstrap_modal.py` command. Instead, it throws the error above.

Below is a more detailed error version: 
```
Traceback (most recent call last):
  File "/home/mutuma/code/Plotly_Dash_Practice/3_charming_data_bootstrap_alerts_n_modals/app.py", line 20, in <module>
    dbc.Form(
  File "/home/mutuma/code/Plotly_Dash_Practice/2_charming_data_bootstrap_cards/venv/lib/python3.10/site-packages/dash/development/base_component.py", line 425, in wrapper
    return func(*args, **kwargs)
  File "/home/mutuma/code/Plotly_Dash_Practice/2_charming_data_bootstrap_cards/venv/lib/python3.10/site-packages/dash_bootstrap_components/_components/Form.py", line 85, in __init__
    super(Form, self).__init__(children=children, **args)
  File "/home/mutuma/code/Plotly_Dash_Practice/2_charming_data_bootstrap_cards/venv/lib/python3.10/site-packages/dash/development/base_component.py", line 143, in __init__
    raise TypeError(
TypeError: The `dash_bootstrap_components.Form` component (version 1.6.0) received an unexpected keyword argument: `inline`
Allowed arguments: action, children, className, class_name, id, key, loading_state, method, n_submit, n_submit_timestamp, prevent_default_on_submit, style
```