### PR TITLE
fix: Import dash library

### DIFF
--- a/Bootstrap/bootstrap_modal.py
+++ b/Bootstrap/bootstrap_modal.py
@@ -2,6 +2,7 @@
 # Docs:     [Dash Bootstrap Components:](https://dash-bootstrap-components.opensource.faculty.ai/docs/components/alert/)
 #           [Dash Bootstrap Themes:](https://dash-bootstrap-components.opensource.faculty.ai/docs/themes/)
 #           [Dash HTML/CORE Components:](https://dash.plotly.com/dash-html-components)
+import dash
 from dash import Dash, dcc, html, Input, Output, State           # pip install dash
 import dash_bootstrap_components as dbc         # pip install dash_bootstrap_components
 import plotly.express as px


### PR DESCRIPTION
Although the app runs prior to importing the dash library, the plot lines don't appear on the chart (Only the axes are shown albeit with erroneous values).

The error associated with this incomplete chart rendering was displayed in a debug window popup and was displayed as: 
```
Traceback (most recent call last):
  File "/home/mutuma/code/Plotly_Dash_Practice/3_charming_data_bootstrap_alerts_n_modals/app.py", line 144, in update_graph_card
    return fig, dash.no_update
NameError: name 'dash' is not defined
```