### PR TITLE
feat: Introduce ModalTitle dbc in Form ModalHeader

### DIFF
--- a/Bootstrap/bootstrap_modal.py
+++ b/Bootstrap/bootstrap_modal.py
@@ -15,7 +15,7 @@ modal = html.Div(
         dbc.Button("Add comment", id="open"),
 
         dbc.Modal([
-            dbc.ModalHeader("All About Berlin"),
+            dbc.ModalHeader(dbc.ModalTitle("All About Berlin", style={"font-size": "24px", "font-style": "italic"})),
             dbc.ModalBody(
                 dbc.Form(
                     [


### PR DESCRIPTION
Including ModalTitle allows easy alteration of font style or font size or both.

According to the [migration guide for dash-bootstrap-components v1](http://bit.ly/4d4M2qs), ModalTitle can be introduced as a child of ModalHeader to conveniently change two font properties: style and size. This change has equally been applied as demonstrated in the official Modal component [documentation](https://bit.ly/3JrBxQc). 